### PR TITLE
Improve colaboradores: better css color for hover + alt descriptions

### DIFF
--- a/assets/css/extended/colaboradores_list.css
+++ b/assets/css/extended/colaboradores_list.css
@@ -40,7 +40,7 @@
 }
 
 .colaboradores-list .colaborador-card:hover {
-  background-color: #252525;
+  background-color: #aaa;
 }
 
 .colaboradores-list .colaborador-card .colaborador-headshot-empty {

--- a/layouts/taxonomy/colaboradores.terms.html
+++ b/layouts/taxonomy/colaboradores.terms.html
@@ -64,7 +64,7 @@
         <a href="{{ $page.Permalink }}">
     {{-     with resources.Get (printf "/images/colaboradores/%s.webp" $slug) }}
           <div class="colaborador-headshot">
-            <img src="{{.Permalink}}" style="view-transition-name: {{$slug}}-headshot;" />
+            <img alt="{{$colaborador.alias}}" src="{{.Permalink}}" style="view-transition-name: {{$slug}}-headshot;" />
           </div>
     {{-     else }}
           <div class="colaborador-headshot-empty"></div>


### PR DESCRIPTION
Color for hover was too dark and the name was barely visible: this should work in both light and dark mode.
Also: added alt descriptions in <img> tags for accesibility